### PR TITLE
chore(ownership): Change package ownership to @fca.gg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hermes-i18n",
+  "name": "@fca.gg/hermes",
   "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hermes-i18n",
+      "name": "@fca.gg/hermes",
       "version": "1.1.3",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
-  "name": "hermes-i18n",
+  "name": "@fca.gg/hermes",
   "version": "1.1.3",
   "main": "dist/index.js",
-  "keywords": [],
-  "author": "IchiiDev",
+  "keywords": [
+    "i18n",
+    "internationalization",
+    "localization",
+    "formatting"
+  ],
+  "author": "FCA.gg",
   "repository": {
-    "url": "https://github.com/IchiiDev/hermes.git"
+    "url": "https://github.com/FCAgreatgoals/hermes.git"
   },
   "license": "ISC",
   "description": "A simple and lightweight i18n library for Node.js",


### PR DESCRIPTION
Updated package info to attribute ownership to the FCA organization. The package name and git repository URL has been updated.

*Credentials need to be updated for the release CI/CD to function correctly with the new NPM ownership.*