### PR TITLE
Add lang total fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fca.gg/hermes",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fca.gg/hermes",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@types/node": "^22.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fca.gg/hermes",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A simple and lightweight i18n library for Node.js",
   "author": "FCA <development@fca.gg>",
   "license": "AGPL-3.0",

--- a/src/classes/Hermes.ts
+++ b/src/classes/Hermes.ts
@@ -69,6 +69,11 @@ export default class Hermes {
         const translations = JSON.parse(readFileSync(`${config.buildDir}/${TRANSLATIONS_FILE_NAME}`, 'utf-8'));
 
         for (const lang of Object.keys(translations) as Array<Langs>) {
+            if (typeof translations[lang] === 'string') {
+                Hermes.instance.translations[lang] = Hermes.instance.translations[translations[lang] as Langs];
+                continue;
+            }
+
             Hermes.instance.translations[lang] = LangData.create(lang, translations[lang]);
         }
 

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -27,7 +27,7 @@ import {
 import { join } from 'path';
 
 import { loadConfig } from '../HermesConfig';
-import { collectLocales, loadTranslations, loadTranslationsRaw } from '../utils';
+import { collectLocales, findTotalFallbackRef, loadTranslations, loadTranslationsRaw } from '../utils';
 import { validateTranslations } from '../validations';
 import { TRANSLATIONS_FILE_NAME } from '../../constants';
 
@@ -46,20 +46,34 @@ export function registerBuildCommand(program: Command) {
 
             const locales = collectLocales(config);
 
-            if (config.checkTranslations) {
-                const rawTranslations: Record<string, Record<string, string>> = {};
+            const rawTranslations: Record<string, Record<string, string>> = {};
+            const totalFallbackRefs: Record<string, string> = {};
 
-                for (const locale of locales) {
-                    rawTranslations[locale] = loadTranslationsRaw(locale, config);
+            for (const locale of locales) {
+                const raw = loadTranslationsRaw(locale, config);
+                const ref = findTotalFallbackRef(locale, raw, config, locales);
+
+                if (ref) {
+                    totalFallbackRefs[locale] = ref;
+                } else {
+                    rawTranslations[locale] = raw;
                 }
+            }
 
+            if (config.checkTranslations) {
                 validateTranslations(rawTranslations);
             }
 
-            const translations: Record<string, Record<string, string>> = {};
+            const translations: Record<string, Record<string, string> | string> = {};
 
             for (const locale of locales) {
-                translations[locale] = loadTranslations(locale, config);
+                if (!totalFallbackRefs[locale]) {
+                    translations[locale] = loadTranslations(locale, config);
+                }
+            }
+
+            for (const [locale, ref] of Object.entries(totalFallbackRefs)) {
+                translations[locale] = ref;
             }
 
             writeFileSync(join(config.buildDir, TRANSLATIONS_FILE_NAME), JSON.stringify(translations));

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -148,3 +148,23 @@ export function loadTranslations(locale: string, config: HermesConfig, visited =
 
     return merged;
 }
+
+export function findTotalFallbackRef(locale: string, raw: Record<string, string>, config: HermesConfig, availableLocales: string[]): string | null {
+    if (Object.keys(raw).length > 0) return null;
+
+    const localeFallbacks = config.fallbackChains[locale] || [];
+    const defaultFallbacks = config.fallbackChains.default || [];
+
+    const fallbacks = [
+        ...localeFallbacks,
+        ...defaultFallbacks.filter(lang => lang !== locale && !localeFallbacks.includes(lang))
+    ];
+
+    for (const fallback of fallbacks) {
+        if (availableLocales.includes(fallback)) {
+            return fallback;
+        }
+    }
+
+    return null;
+}


### PR DESCRIPTION
If a language has a file or a folder but no keys are defined inside it, the fallback chain is executed at build time to determine the correct language, and the compiled file only contains `"locale": "fallback"`.

At runtime, this is interpreted as a reference to the fallback object.

It reduce the size of the compiled file as well as the amount of RAM used at runtime.